### PR TITLE
Add shorthand scripts for project bootstrapping

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+set -e
+
+virtualenv -p python3 venv
+source venv/bin/activate
+pip install -r requirements.txt
+bower install
+./manage.py compilemessages
+./manage.py migrate
+echo
+echo "Creating super user, enter credentials:"
+./manage.py createsuperuser
+deactivate
+
+echo
+echo "environment successfully bootstrapped. Start a server with script/server"

--- a/script/server
+++ b/script/server
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+set -e
+
+source venv/bin/activate
+./manage.py runserver

--- a/script/update
+++ b/script/update
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+set -e
+
+source venv/bin/activate
+pip install -r requirements.txt
+bower install
+./manage.py compilemessages
+./manage.py migrate


### PR DESCRIPTION
This PR adds some shorthand scripts to speed up initial project setup in development:

 * `script/bootstrap` Setup initial development environment
 * `script/update` Update dependencies, but discard no already existing data
 * `script/server` Run the Django development server on port 8000

These scripts are based on GitHub's [scripts to rule them all](http://githubengineering.com/scripts-to-rule-them-all/)