### PR TITLE
Set session and csrf cookie names to be unique to the application

### DIFF
--- a/pyophase/settings.py
+++ b/pyophase/settings.py
@@ -143,3 +143,7 @@ EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
 ### PYTUID ###
 
 TUID_SERVER_URL = 'https://sso.tu-darmstadt.de'
+
+# application-specific-cookies
+CSRF_COOKIE_NAME = 'pyophase_csrftoken'
+SESSION_COOKIE_NAME = 'pyophase_sessionid'


### PR DESCRIPTION
Since we host everything from one domain, the same cookie names are used and overwritten by every django application. This pr fixes this by prepending the cookie names with an identifier (pyophase)