### PR TITLE
Switch back to ophasehq subdirectory in production

### DIFF
--- a/pyophase/settings_production.py
+++ b/pyophase/settings_production.py
@@ -29,9 +29,11 @@ DATABASES = {
     }
 }
 
-STATIC_URL = '/ophasehq/static/'
-LOGIN_URL = '/ophasehq/accounts/login/'
-MEDIA_URL = '/ophasehq/media/'
+BASE_PATH = '/ophasehq'
+
+STATIC_URL = BASE_PATH + '/static/'
+LOGIN_URL = BASE_PATH + '/accounts/login/'
+MEDIA_URL = BASE_PATH + '/media/'
 
 SESSION_COOKIE_SECURE = True
 

--- a/pyophase/settings_production.py
+++ b/pyophase/settings_production.py
@@ -29,9 +29,9 @@ DATABASES = {
     }
 }
 
-STATIC_URL = '/ophase/static/'
-LOGIN_URL = '/ophase/accounts/login/'
-MEDIA_URL = '/ophase/media/'
+STATIC_URL = '/ophasehq/static/'
+LOGIN_URL = '/ophasehq/accounts/login/'
+MEDIA_URL = '/ophasehq/media/'
 
 SESSION_COOKIE_SECURE = True
 

--- a/templates/admin/base_site.html
+++ b/templates/admin/base_site.html
@@ -36,7 +36,7 @@ oplan.is_staff = "{{user.is_staff}}";
 {% block branding %}
 <h1 id="site-name">
   <!--<a href="/"><i class="fa fa-bars mobile-only"></i><i class="fa fa-map mobile-hidden"></i>&nbsp;&nbsp;pyOphase</a>-->
-<a href="/ophase"><img src="{% static "ophasebase/pyophase-light.png" %}" alt="pyophase" style="height:40px"></a>
+<a href="/ophasehq"><img src="{% static "ophasebase/pyophase-light.png" %}" alt="pyophase" style="height:40px"></a>
 </h1>
 {% endblock %}
 


### PR DESCRIPTION
These seem to be the only locations this url is set ~but I will take a longer look later~.
I looked and there is no other location. I took the liberty and added the hacktoberfest-accepted label, feel free to remove it if you do not feel that it would apply here.