### PR TITLE
Drop python 3.6 support, add python 3.10

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
+        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
 
     services:
       mariadb:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [ 3.7, 3.8, 3.9, 3.10 ]
+        python-version: [ 3.7, 3.8, 3.9, '3.10' ]
 
     services:
       mariadb:


### PR DESCRIPTION
I think it's time to drop support for python 3.6 to make sure we can keep the external dependencies up to date.

Therefore, I suggest we remove python 3.6 from the CI test matrix, and add python 3.10.